### PR TITLE
Fix(command): duplicated `Other Commands:` in help menu

### DIFF
--- a/cmd/local/longhornctl-local.go
+++ b/cmd/local/longhornctl-local.go
@@ -61,15 +61,10 @@ func newCmdLonghornctlLocal() *cobra.Command {
 				localsubcmd.NewCmdGet(globalOpts),
 			},
 		},
-		{
-			Message: "Other Commands:",
-			Commands: []*cobra.Command{
-				localsubcmd.NewCmdVersion(),
-			},
-		},
 	}
 	groups.Add(cmd)
 
+	cmd.AddCommand(localsubcmd.NewCmdVersion())
 	cmd.AddCommand(remotesubcmd.NewCmdGlobalOptions())
 
 	filters := []string{"options"}

--- a/cmd/remote/longhornctl.go
+++ b/cmd/remote/longhornctl.go
@@ -63,15 +63,10 @@ func newCmdLonghornctl() *cobra.Command {
 				subcmd.NewCmdGet(globalOpts),
 			},
 		},
-		{
-			Message: "Other Commands:",
-			Commands: []*cobra.Command{
-				subcmd.NewCmdVersion(globalOpts),
-			},
-		},
 	}
 	groups.Add(cmd)
 
+	cmd.AddCommand(subcmd.NewCmdVersion())
 	cmd.AddCommand(subcmd.NewCmdGlobalOptions())
 
 	filters := []string{"options"}

--- a/cmd/remote/subcmd/version.go
+++ b/cmd/remote/subcmd/version.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/longhorn/cli/meta"
 	"github.com/longhorn/cli/pkg/consts"
-	"github.com/longhorn/cli/pkg/types"
 )
 
-func NewCmdVersion(globalOpts *types.GlobalCmdOptions) *cobra.Command {
+func NewCmdVersion() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   consts.SubCmdVersion,
 		Short: fmt.Sprintf("Print %s version", consts.CmdLonghornctlRemote),


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue `None`

#### What this PR does / why we need it:

Remove duplicated `Other commands:` in the help menu.

```
CLI for Longhorn troubleshooting and operations.

Install And Uninstall Commands:
  install          Longhorn installation operations

Operation Commands:
  trim             Longhorn trimming operations
  export           Export Longhorn resources

Troubleshoot Commands:
  check            Longhorn checking operations
  get              Longhorn information gathering operations

Other Commands:
  version          Print longhornctl version

Other Commands:
  global-options   Print global options inherited by all subcommands

Use "longhornctl <command> --help" for more information about a given command.
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
