### PR TITLE
fix(spdk): enable uio_pci_generic and vfio_pci kernel modules

### DIFF
--- a/cmd/remote/subcmd/check.go
+++ b/cmd/remote/subcmd/check.go
@@ -5,8 +5,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	lhtypes "github.com/longhorn/go-common-libs/types"
-
 	"github.com/longhorn/cli/pkg/consts"
 	"github.com/longhorn/cli/pkg/remote/preflight"
 	"github.com/longhorn/cli/pkg/types"
@@ -99,7 +97,7 @@ INFO[2024-07-16T17:17:42+08:00] Completed preflight checker`,
 
 	cmd.Flags().BoolVar(&preflightChecker.EnableSpdk, consts.CmdOptEnableSpdk, false, "Enable checking of SPDK required packages, modules, and setup.")
 	cmd.Flags().IntVar(&preflightChecker.HugePageSize, consts.CmdOptHugePageSize, 2048, "Specify the huge page size in MiB for SPDK.")
-	cmd.Flags().StringVar(&preflightChecker.UserspaceDriver, consts.CmdOptUserspaceDriver, string(lhtypes.DiskDriverVfioPci), "Userspace I/O driver for SPDK.")
+	cmd.Flags().StringVar(&preflightChecker.UserspaceDriver, consts.CmdOptUserspaceDriver, "", "Userspace I/O driver for SPDK.")
 
 	return cmd
 }

--- a/cmd/remote/subcmd/install.go
+++ b/cmd/remote/subcmd/install.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	lhtypes "github.com/longhorn/go-common-libs/types"
-
 	"github.com/longhorn/cli/pkg/consts"
 	"github.com/longhorn/cli/pkg/remote/preflight"
 	"github.com/longhorn/cli/pkg/types"
@@ -91,7 +89,7 @@ INFO[2024-07-16T17:09:08+08:00] Completed preflight installer. Use 'longhornctl 
 	cmd.Flags().StringVar(&preflightInstaller.SpdkOptions, consts.CmdOptSpdkOptions, "", fmt.Sprintf("Specify a comma-separated (%s) list of custom options for configuring SPDK environment.", consts.CmdOptSeperator))
 	cmd.Flags().IntVar(&preflightInstaller.HugePageSize, consts.CmdOptHugePageSize, 2048, "Specify the huge page size in MiB for SPDK.")
 	cmd.Flags().StringVar(&preflightInstaller.AllowPci, consts.CmdOptAllowPci, "none", fmt.Sprintf("Specify a comma-separated (%s) list of allowed PCI devices. By default, all PCI devices are blocked by a non-valid address.", consts.CmdOptSeperator))
-	cmd.Flags().StringVar(&preflightInstaller.DriverOverride, consts.CmdOptDriverOverride, string(lhtypes.DiskDriverVfioPci), "Userspace driver for device bindings. Override default driver for PCI devices.")
+	cmd.Flags().StringVar(&preflightInstaller.DriverOverride, consts.CmdOptDriverOverride, "", "Userspace driver for device bindings. Override default driver for PCI devices.")
 
 	return cmd
 }

--- a/pkg/local/preflight/checker.go
+++ b/pkg/local/preflight/checker.go
@@ -108,6 +108,8 @@ func (local *Checker) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 
 	case pkgmgr.PackageManagerYum:
@@ -122,6 +124,8 @@ func (local *Checker) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 
 	case pkgmgr.PackageManagerZypper:
@@ -136,6 +140,8 @@ func (local *Checker) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 
 	case pkgmgr.PackageManagerPacman:
@@ -150,6 +156,8 @@ func (local *Checker) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 
 	default:

--- a/pkg/local/preflight/installer.go
+++ b/pkg/local/preflight/installer.go
@@ -86,7 +86,9 @@ func (local *Installer) Init() error {
 			"linux-modules-extra-" + kernelRelease,
 		}
 		local.spdkDepModules = []string{
-			"nvme-tcp",
+			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 		return nil
 
@@ -104,6 +106,8 @@ func (local *Installer) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 		return nil
 
@@ -121,6 +125,8 @@ func (local *Installer) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 		return nil
 
@@ -138,6 +144,8 @@ func (local *Installer) Init() error {
 		local.spdkDepPackages = []string{}
 		local.spdkDepModules = []string{
 			"nvme_tcp",
+			"uio_pci_generic",
+			"vfio_pci",
 		}
 		return nil
 


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9182

#### What this PR does / why we need it:

According to the [SPDK System Configuration User Guide](https://spdk.io/doc/system_configuration.html), neither `uio_pci_generic` nor `vfio_pci` is universally suitable for all devices and environments. Therefore, the preflight installation enables both `uio_pci_generic` and `vfio_pci` kernel modules, allowing spdk/setup.sh to automatically select the appropriate module.



#### Special notes for your reviewer:

#### Additional documentation or context
