### PR TITLE
fix: check kernel module `dm_crypt` on host machines

### DIFF
--- a/pkg/local/preflight/checker.go
+++ b/pkg/local/preflight/checker.go
@@ -101,7 +101,9 @@ func (local *Checker) Init() error {
 		local.packages = []string{
 			"nfs-common", "open-iscsi",
 		}
-		local.modules = []string{}
+		local.modules = []string{
+			"dm_crypt",
+		}
 		local.services = []string{
 			"multipathd.service",
 		}
@@ -117,7 +119,9 @@ func (local *Checker) Init() error {
 		local.packages = []string{
 			"nfs-utils", "iscsi-initiator-utils",
 		}
-		local.modules = []string{}
+		local.modules = []string{
+			"dm_crypt",
+		}
 		local.services = []string{
 			"multipathd.service",
 		}
@@ -133,7 +137,9 @@ func (local *Checker) Init() error {
 		local.packages = []string{
 			"nfs-client", "open-iscsi",
 		}
-		local.modules = []string{}
+		local.modules = []string{
+			"dm_crypt",
+		}
 		local.services = []string{
 			"multipathd.service",
 		}
@@ -149,7 +155,9 @@ func (local *Checker) Init() error {
 		local.packages = []string{
 			"nfs-utils", "open-iscsi",
 		}
-		local.modules = []string{}
+		local.modules = []string{
+			"dm_crypt",
+		}
 		local.services = []string{
 			"multipathd.service",
 		}
@@ -189,6 +197,10 @@ func (local *Checker) Run() error {
 		}
 
 		if err := local.checkPackagesInstalled(false); err != nil {
+			return err
+		}
+
+		if err := local.checkModulesLoaded(false); err != nil {
 			return err
 		}
 

--- a/pkg/local/preflight/installer.go
+++ b/pkg/local/preflight/installer.go
@@ -77,7 +77,7 @@ func (local *Installer) Init() error {
 			"nfs-common", "open-iscsi",
 		}
 		local.modules = []string{
-			"nfs",
+			"nfs", "dm_crypt",
 		}
 		local.services = []string{
 			"iscsid",
@@ -98,7 +98,7 @@ func (local *Installer) Init() error {
 			"nfs-utils", "iscsi-initiator-utils",
 		}
 		local.modules = []string{
-			"nfs", "iscsi_tcp",
+			"nfs", "iscsi_tcp", "dm_crypt",
 		}
 		local.services = []string{
 			"iscsid",
@@ -117,7 +117,7 @@ func (local *Installer) Init() error {
 			"nfs-client", "open-iscsi",
 		}
 		local.modules = []string{
-			"nfs", "iscsi_tcp",
+			"nfs", "iscsi_tcp", "dm_crypt",
 		}
 		local.services = []string{
 			"iscsid",
@@ -136,7 +136,7 @@ func (local *Installer) Init() error {
 			"nfs-utils", "open-iscsi",
 		}
 		local.modules = []string{
-			"nfs", "iscsi_tcp",
+			"nfs", "iscsi_tcp", "dm_crypt",
 		}
 		local.services = []string{
 			"iscsid",


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9153

#### What this PR does / why we need it:
- check if the module `dm_crypt` is enabled
- enable the module `dm_crypt`

#### Special notes for your reviewer:

#### Additional documentation or context
