### PR TITLE
fix(install): install packages before starting services

### DIFF
--- a/pkg/local/preflight/installer.go
+++ b/pkg/local/preflight/installer.go
@@ -161,15 +161,15 @@ func (local *Installer) Run() error {
 		}
 	}
 
-	if err := local.startServices(); err != nil {
-		return err
-	}
-
 	if err := local.probeModules(consts.DependencyModuleDefault); err != nil {
 		return err
 	}
 
 	if err := local.installPackages(false); err != nil {
+		return err
+	}
+
+	if err := local.startServices(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
On SLES OS, the iSCSI package is not installed by default, so longhornctl should install the package before starting the iSCSI service.



Issue longhorn/longhorn#9182

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
