### PR TITLE
fix(preflight): check APT package installation by status flag

### DIFF
--- a/pkg/local/preflight/packagemanager/apt.go
+++ b/pkg/local/preflight/packagemanager/apt.go
@@ -1,6 +1,7 @@
 package packagemanager
 
 import (
+	"strings"
 	"time"
 
 	commonns "github.com/longhorn/go-common-libs/ns"
@@ -64,6 +65,20 @@ func (c *AptPackageManager) GetServiceStatus(name string) (string, error) {
 }
 
 // CheckPackageInstalled checks if a package is installed
-func (c *AptPackageManager) CheckPackageInstalled(name string) (string, error) {
-	return c.executor.Execute([]string{}, "dpkg-query", []string{"-l", name}, commontypes.ExecuteNoTimeout)
+func (c *AptPackageManager) CheckPackageInstalled(name string) (output string, err error) {
+	// Check man 1 dpkg-query for status flags.
+	// example for an installed package:
+	// $ dpkg-query -f='${binary:Package} ${db:Status-Abbrev}' -W nfs-common
+	// nfs-common ii
+	output, err = c.executor.Execute([]string{}, "dpkg-query", []string{"-f=${binary:Package} ${db:Status-Abbrev}", "-W", name}, commontypes.ExecuteNoTimeout)
+	if err != nil {
+		return
+	}
+	fields := strings.Fields(strings.TrimSpace(output))
+	if len(fields) == 2 {
+		if fields[0] == name && fields[1] == "ii" {
+			return output, nil
+		}
+	}
+	return output, packageNotInstalledError
 }

--- a/pkg/local/preflight/packagemanager/packagemanager.go
+++ b/pkg/local/preflight/packagemanager/packagemanager.go
@@ -1,6 +1,7 @@
 package packagemanager
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,6 +19,8 @@ const (
 	PackageManagerPacman              = PackageManagerType("pacman")
 	// PackageManagerQlist            = PackageManagerType("qlist")
 )
+
+var packageNotInstalledError = errors.New("package not installed")
 
 type PackageManager interface {
 	UpdatePackageList() (string, error)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9495

#### What this PR does / why we need it:

While checking the installation status with APT package system, we should read the actual package status instead of the exit code of `dpkg-query -l` or `dpkg -l`.

#### Special notes for your reviewer:

#### Additional documentation or context
