### PR TITLE
fix(dep): not found transitive dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,3 +104,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace (
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.3
+	k8s.io/kubelet => k8s.io/kubelet v0.31.3
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -928,3 +928,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.3
+# k8s.io/kubelet => k8s.io/kubelet v0.31.3


### PR DESCRIPTION
Signed-off-by: davidko <dko@suse.com>

#### Which issue(s) this PR fixes:

When running `go list -mod=mod -m all` will encounter the transitive dependencies not found. 
It shouldn't impact the code compilation as the dependencies are not used, but it might affect the dependencies resolution in IDEs.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
