### PR TITLE
feat: Add Raspbian OS support to Longhorn CLI

### DIFF
--- a/pkg/utils/os.go
+++ b/pkg/utils/os.go
@@ -21,7 +21,7 @@ func GetPackageManagerType(osRelease string) (pkgmgr.PackageManagerType, error) 
 		return pkgmgr.PackageManagerZypper, nil
 	case "sl-micro":
 		return pkgmgr.PackageManagerTransactionalUpdate, nil
-	case "ubuntu", "debian":
+	case "ubuntu", "debian", "raspbian":
 		return pkgmgr.PackageManagerApt, nil
 	case "rhel", "ol", "rocky", "centos", "fedora", "amzn":
 		return pkgmgr.PackageManagerYum, nil


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue [longhorn/longhorn/issues/10676
](https://github.com/longhorn/longhorn/issues/10676)

#### What this PR does / why we need it:

This PR adds support for Raspbian OS in the Longhorn CLI by identifying it as a Debian derivative and using the appropriate package manager (apt).

