### PR TITLE
fix(workflow): generate token only when github.ref_type is tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
 
     - id: app-token
       uses: actions/create-github-app-token@v2
+      if: github.ref_type == 'tag'
       with:
         app-id: ${{ secrets.LONGHORN_GITHUB_BOT_APP_ID }}
         private-key: ${{ secrets.LONGHORN_GITHUB_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
