### PR TITLE
fix(platform): enhance platform detection for transactional suse

### DIFF
--- a/pkg/utils/os.go
+++ b/pkg/utils/os.go
@@ -122,31 +122,55 @@ func GetOSRelease() (string, error) {
 func parseOSreleaseFile(lines []string) (string, error) {
 	// First, try using `ID_LIKE` because some users might be on customized OS with a modified `ID`,
 	// making it difficult to determine things like the proper package manager. If `ID_LIKE` is not found, use `ID`.
-	platformRexp := regexp.MustCompile(`^ID_LIKE=["']?(.+?)["']?\n?$`)
-	platform := parsePlatform(lines, platformRexp)
-	if platform == "" {
-		platformRexp = regexp.MustCompile(`^ID=["']?(.+?)["']?\n?$`)
-		platform = parsePlatform(lines, platformRexp)
+
+	// Priority keywords that should be preferred over the first word in multi-word values.
+	// SLE Micro 6.1 has ID_LIKE="suse sle-micro ..." but we need "sl-micro" for transactional-update support.
+	// Map from any variant to the canonical form expected by GetPackageManagerType.
+	platformKeywordMap := map[string]string{
+		"sle-micro": "sl-micro",
+		"sl-micro":  "sl-micro",
 	}
 
-	if platform == "" {
-		return "", fmt.Errorf("could not find platform information in os-release: %v", lines)
+	// Try ID_LIKE first, then ID, using the same parsing logic for both
+	regexPatterns := []string{
+		`^ID_LIKE=["']?(.+?)["']?\n?$`,
+		`^ID=["']?(.+?)["']?\n?$`,
 	}
 
-	return platform, nil
+	for _, pattern := range regexPatterns {
+		platformRexp := regexp.MustCompile(pattern)
+		if platform := parsePlatform(lines, platformRexp, platformKeywordMap); platform != "" {
+			return platform, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find platform information in os-release: %v", lines)
 }
 
-func parsePlatform(lines []string, platformRexp *regexp.Regexp) (platforms string) {
+// parsePlatform extracts platform information from os-release lines.
+// If platformKeywordMap is provided, it checks if any key exists in the full matched value
+// and returns the corresponding canonical value instead of just taking the first word.
+// This handles cases like ID_LIKE="suse sle-micro ..." where we want "sl-micro" not "suse".
+// If platformKeywordMap is nil or empty, it returns the first word of the matched value.
+func parsePlatform(lines []string, platformRexp *regexp.Regexp, platformKeywordMap map[string]string) string {
 	for _, line := range lines {
 		match := platformRexp.FindStringSubmatch(line)
 		if len(match) > 0 {
-			platforms = match[1]
-			break
+			fullValue := match[1]
+
+			// Check if any priority keyword exists in the full value
+			for keyword, canonical := range platformKeywordMap {
+				if strings.Contains(fullValue, keyword) {
+					return canonical
+				}
+			}
+
+			// Fall back to first-word behavior
+			fields := strings.Fields(fullValue)
+			if len(fields) > 0 {
+				return fields[0]
+			}
 		}
-	}
-	fields := strings.Fields(platforms)
-	if len(fields) > 0 {
-		return fields[0]
 	}
 	return ""
 }

--- a/pkg/utils/os_test.go
+++ b/pkg/utils/os_test.go
@@ -28,6 +28,14 @@ func TestParseOSreleaseFile(t *testing.T) {
 			output: "my-os",
 		},
 		{
+			input:  []string{"ID=\"sl-micro\"", "ID_LIKE=\"suse sle-micro opensuse-microos microos\""},
+			output: "sl-micro",
+		},
+		{
+			input:  []string{"ID=\"sl-micro\"", "ID_LIKE=\"suse sl-micro\""},
+			output: "sl-micro",
+		},
+		{
 			input:  []string{""},
 			output: "",
 		},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13048

#### What this PR does / why we need it:

#### Special notes for your reviewer:

The target SUSE SLE os-release file sample:

```
NAME="SL-Micro"
VERSION="6.1"
VERSION_ID="6.1"
PRETTY_NAME="SUSE Linux Micro 6.1"
ID="sl-micro"
ID_LIKE="suse sle-micro opensuse-microos microos"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sl-micro:6.1"
HOME_URL="https://www.suse.com/products/micro/"
DOCUMENTATION_URL="https://documentation.suse.com/sl-micro/6.1/"
LOGO="distributor-logo"
```

#### Additional documentation or context
