### PR TITLE
fix: return defaultValue on conversion failure in ConvertStringToTypeOrDefault

### DIFF
--- a/pkg/utils/cmd.go
+++ b/pkg/utils/cmd.go
@@ -105,17 +105,17 @@ func ConvertStringToTypeOrDefault[T any](str string, defaultValue T) T {
 		intValue, err := strconv.Atoi(str)
 		if err != nil {
 			logrus.WithError(err).Warn("Failed to convert string to integer")
-		} else {
-			value = reflect.ValueOf(intValue).Interface().(T)
+			return defaultValue
 		}
+		value = reflect.ValueOf(intValue).Interface().(T)
 
 	case reflect.Bool:
 		boolValue, err := strconv.ParseBool(str)
 		if err != nil {
 			logrus.WithError(err).Warn("Failed to convert string to boolean")
-		} else {
-			value = reflect.ValueOf(boolValue).Interface().(T)
+			return defaultValue
 		}
+		value = reflect.ValueOf(boolValue).Interface().(T)
 
 	default:
 		logrus.WithField("type", reflect.TypeOf(defaultValue)).Warn("Unsupported default value type")

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -2,6 +2,36 @@ package utils
 
 import "testing"
 
+func TestConvertStringToTypeOrDefault(t *testing.T) {
+	for testName, testCase := range map[string]struct {
+		input        string
+		defaultValue any
+		expected     any
+	}{
+		"empty string returns default int":      {"", 2048, 2048},
+		"valid int string":                      {"4096", 2048, 4096},
+		"invalid int returns default":           {"bad", 2048, 2048},
+		"empty string returns default bool":     {"", true, true},
+		"valid bool string true":                {"true", false, true},
+		"valid bool string false":               {"false", true, false},
+		"invalid bool returns default":          {"bad", true, true},
+		"invalid bool returns default (false)":  {"bad", false, false},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			var got any
+			switch d := testCase.defaultValue.(type) {
+			case int:
+				got = ConvertStringToTypeOrDefault(testCase.input, d)
+			case bool:
+				got = ConvertStringToTypeOrDefault(testCase.input, d)
+			}
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
 func TestBuildImageName(t *testing.T) {
 	for testName, testCase := range map[string]struct {
 		expected, image, globalRegistry string

--- a/pkg/utils/kubernetes/runtime.go
+++ b/pkg/utils/kubernetes/runtime.go
@@ -160,7 +160,7 @@ func NewWorkload(kubeClient *kubeclient.Clientset, obj interface{}, kind, labelS
 		"kind":            kind,
 		"namespace":       namespace,
 		"name":            name,
-		"lable-selectors": labelSelector,
+		"label-selectors": labelSelector,
 	})
 	return &Workload{
 		logger:         logger,

--- a/pkg/utils/longhorn/longhorn.go
+++ b/pkg/utils/longhorn/longhorn.go
@@ -54,7 +54,7 @@ func GetDataDirectory(logger *logrus.Entry, hostDirectory, inputDataDirectory st
 					return "", err
 				}
 			} else {
-				return "", errors.Wrapf(err, "directory %s does not exist", dataDir)
+				return "", errors.Wrapf(err, "failed to stat directory %s", dataDir)
 			}
 		}
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#10000

#### What this PR does / why we need it:

`ConvertStringToTypeOrDefault` doc says "if conversion fails, return the default value" but the code returns the zero value (`0` for int, `false` for bool) instead. So `LONGHORN_SPDK_HUGE_PAGE_SIZE=garbage` silently sets huge page size to `0` rather than the default `2048`.

Also: typo `lable-selectors` -> `label-selectors` in a log field, and a misleading `"does not exist"` error message in a non-ENOENT stat error branch.

#### Special notes for your reviewer:

Reproduce:
```go
ConvertStringToTypeOrDefault("garbage", 2048) // was: 0, now: 2048
ConvertStringToTypeOrDefault("garbage", true) // was: false, now: true
```

#### Additional documentation or context