### PR TITLE
fix: recognize OpenCloudOS as a yum-based distribution

### DIFF
--- a/pkg/utils/os.go
+++ b/pkg/utils/os.go
@@ -23,7 +23,7 @@ func GetPackageManagerType(osRelease string) (pkgmgr.PackageManagerType, error) 
 		return pkgmgr.PackageManagerTransactionalUpdate, nil
 	case "ubuntu", "debian":
 		return pkgmgr.PackageManagerApt, nil
-	case "rhel", "ol", "rocky", "centos", "fedora", "amzn":
+	case "rhel", "ol", "rocky", "centos", "fedora", "amzn", "opencloudos":
 		return pkgmgr.PackageManagerYum, nil
 	case "arch":
 		return pkgmgr.PackageManagerPacman, nil

--- a/pkg/utils/os_test.go
+++ b/pkg/utils/os_test.go
@@ -144,6 +144,12 @@ func TestGetPackageManagerType(t *testing.T) {
 			shouldFail: false,
 		},
 		{
+			name:       "OpenCloudOS",
+			osRelease:  "opencloudos",
+			wantType:   pkgmgr.PackageManagerYum,
+			shouldFail: false,
+		},
+		{
 			name:       "Arch Linux",
 			osRelease:  "arch",
 			wantType:   pkgmgr.PackageManagerPacman,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#12095

#### What this PR does / why we need it:

OpenCloudOS 9 reports `ID=opencloudos`. The CLI currently does not map that ID to a package-manager type, so the preflight checker exits with:

```
failed to get package manager: operating system (opencloudos) is not supported
```

OpenCloudOS provides DNF/Yum package management. This change maps `opencloudos` to `PackageManagerYum` and adds a unit test for the mapping, allowing the normal prerequisite checks to run instead of failing during OS detection.

#### Special notes for your reviewer:

This change addresses the package-manager detection failure. The existing preflight checks continue to validate required packages, services, and kernel modules on the host.

Validation performed:

```
go test -parallel 1 -tags=test ./...
go vet ./...
```

#### Additional documentation or context

OpenCloudOS package management documentation lists DNF and Yum as the supported package-management tools:
https://docs.opencloudos.org/en/OCS/AdministratorGuide/Software_Management/
