### PR TITLE
fix(cmd): add stop subcommand to check preflight, trim volume, and get replica

### DIFF
--- a/cmd/remote/subcmd/check.go
+++ b/cmd/remote/subcmd/check.go
@@ -97,11 +97,55 @@ INFO[2024-07-16T17:17:42+08:00] Completed preflight checker`,
 		},
 	}
 
+	cmd.AddCommand(newCmdCheckPreflightStop(globalOpts))
+
 	utils.SetGlobalOptionsRemote(cmd, globalOpts)
 
 	cmd.Flags().BoolVar(&preflightChecker.EnableSpdk, consts.CmdOptEnableSpdk, false, "Enable checking of SPDK required packages, modules, and setup.")
 	cmd.Flags().IntVar(&preflightChecker.HugePageSize, consts.CmdOptHugePageSize, 2048, "Specify the huge page size in MiB for SPDK.")
 	cmd.Flags().StringVar(&preflightChecker.UserspaceDriver, consts.CmdOptUserspaceDriver, "", "Userspace I/O driver for SPDK.")
+
+	return cmd
+}
+
+func newCmdCheckPreflightStop(globalOpts *types.GlobalCmdOptions) *cobra.Command {
+	var preflightChecker = preflight.Checker{}
+
+	cmd := &cobra.Command{
+		Use:   consts.SubCmdStop,
+		Short: "Stop Longhorn preflight checker",
+		Long:  `This command terminates the preflight checker.`,
+		Example: `$ longhornctl check preflight stop
+INFO[2024-07-16T17:21:32+08:00] Stopping preflight checker
+INFO[2024-07-16T17:21:32+08:00] Successfully stopped preflight checker`,
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preflightChecker.KubeConfigPath = globalOpts.KubeConfigPath
+			preflightChecker.Namespace = globalOpts.Namespace
+
+			if err := preflightChecker.Init(); err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to initialize preflight checker"))
+			}
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			logrus.Info("Stopping preflight checker")
+
+			err := preflightChecker.Cleanup()
+			if err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to stop preflight checker"))
+			}
+
+			logrus.Info("Successfully stopped preflight checker")
+		},
+	}
+
+	utils.SetGlobalOptionsRemote(cmd, globalOpts)
+
+	// Hidden, not removed, so `stop` can be appended to the parent command as-is.
+	utils.SetFlagHidden(cmd, consts.CmdOptEnableSpdk)
+	utils.SetFlagHidden(cmd, consts.CmdOptHugePageSize)
+	utils.SetFlagHidden(cmd, consts.CmdOptUserspaceDriver)
 
 	return cmd
 }

--- a/cmd/remote/subcmd/get.go
+++ b/cmd/remote/subcmd/get.go
@@ -101,11 +101,55 @@ INFO[2024-07-16T17:23:51+08:00] Completed replica getter`,
 		},
 	}
 
+	cmd.AddCommand(newCmdGetReplicaStop(globalOpts))
+
 	utils.SetGlobalOptionsRemote(cmd, globalOpts)
 
 	cmd.Flags().StringVar(&replicaGetter.ReplicaName, consts.CmdOptName, "", "Specify the name of the replica to retrieve information.")
 	cmd.Flags().StringVar(&replicaGetter.VolumeName, consts.CmdOptLonghornVolumeName, "", "Specify the name of the volume to retrieve replica information.")
 	cmd.Flags().StringVar(&replicaGetter.LonghornDataDirectory, consts.CmdOptLonghornDataDirectory, "/var/lib/longhorn", "Specify the Longhorn data directory. If not provided, the default will be attempted, or it will fall back to the directory of longhorn-disk.cfg.")
+
+	return cmd
+}
+
+func newCmdGetReplicaStop(globalOpts *types.GlobalCmdOptions) *cobra.Command {
+	var replicaGetter = replica.Getter{}
+
+	cmd := &cobra.Command{
+		Use:   consts.SubCmdStop,
+		Short: "Stop the replica getter",
+		Long:  `This command terminates the ongoing replica information retrieval and stops the replica getter.`,
+		Example: `$ longhornctl get replica stop
+INFO[2024-07-16T17:29:14+08:00] Stopping replica getter
+INFO[2024-07-16T17:29:14+08:00] Successfully stopped replica getter`,
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			replicaGetter.KubeConfigPath = globalOpts.KubeConfigPath
+			replicaGetter.Namespace = globalOpts.Namespace
+
+			if err := replicaGetter.Init(); err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to initialize replica getter"))
+			}
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			logrus.Info("Stopping replica getter")
+
+			err := replicaGetter.Cleanup()
+			if err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to stop replica getter"))
+			}
+
+			logrus.Info("Successfully stopped replica getter")
+		},
+	}
+
+	utils.SetGlobalOptionsRemote(cmd, globalOpts)
+
+	// Hidden, not removed, so `stop` can be appended to the parent command as-is.
+	utils.SetFlagHidden(cmd, consts.CmdOptName)
+	utils.SetFlagHidden(cmd, consts.CmdOptLonghornVolumeName)
+	utils.SetFlagHidden(cmd, consts.CmdOptLonghornDataDirectory)
 
 	return cmd
 }

--- a/cmd/remote/subcmd/trim.go
+++ b/cmd/remote/subcmd/trim.go
@@ -86,9 +86,51 @@ INFO[2024-07-16T17:32:01+08:00] Completed volume trimmer                      vo
 		},
 	}
 
+	cmd.AddCommand(newCmdTrimVolumeStop(globalOpts))
+
 	utils.SetGlobalOptionsRemote(cmd, globalOpts)
 
 	cmd.Flags().StringVar(&volumeTrimmer.VolumeName, consts.CmdOptName, "", "Name of the Longhorn volum to be trimmed.")
+
+	return cmd
+}
+
+func newCmdTrimVolumeStop(globalOpts *types.GlobalCmdOptions) *cobra.Command {
+	var volumeTrimmer = volume.Trimmer{}
+
+	cmd := &cobra.Command{
+		Use:   consts.SubCmdStop,
+		Short: "Stop the volume trimmer",
+		Long:  `This command terminates the ongoing volume trim process and stops the volume trimmer.`,
+		Example: `$ longhornctl trim volume --name="pvc-48a6457d-585e-423b-b530-bbc68a5f948a" stop
+INFO[2024-07-16T17:29:14+08:00] Stopping volume trimmer
+INFO[2024-07-16T17:29:14+08:00] Successfully stopped volume trimmer`,
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			volumeTrimmer.KubeConfigPath = globalOpts.KubeConfigPath
+			volumeTrimmer.Namespace = globalOpts.Namespace
+
+			if err := volumeTrimmer.Init(); err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to initialize volume trimmer"))
+			}
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			logrus.Info("Stopping volume trimmer")
+
+			err := volumeTrimmer.Cleanup()
+			if err != nil {
+				utils.CheckErr(errors.Wrap(err, "Failed to stop volume trimmer"))
+			}
+
+			logrus.Info("Successfully stopped volume trimmer")
+		},
+	}
+
+	utils.SetGlobalOptionsRemote(cmd, globalOpts)
+
+	// Hidden, not removed, so `stop` can be appended to the parent command as-is.
+	utils.SetFlagHidden(cmd, consts.CmdOptName)
 
 	return cmd
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#9311

#### What this PR does / why we need it:
A `stop` command has been added to `check preflight`, `trim volume`, and `get replica`. 
`checksum` was deliberately excluded: its `Cleanup()` is a no-op, as it merely
updates the Volume CR directly and does not create any cluster resources that
could become orphaned.

#### Special notes for your reviewer:
- Each `stop` command follows the exact pattern of `export replica stop`.
- None of the three new commands requires a parent flag to remain visible in `stop`
- Manually validated: I interrupted each parent command mid-execution, confirmed that the DaemonSet/RBAC resources were left orphaned, and then verified that the new `stop` command removes them.

#### Additional documentation or context